### PR TITLE
Robot::WaitUntilReady: Call SendInit if the ackn has not happend yet

### DIFF
--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -167,9 +167,15 @@ void Robot::WaitUntilReady()
         if (((std::chrono::duration<double>)(std::chrono::system_clock::now() - last)).count() > 0.001)
         {
             last += std::chrono::milliseconds(1);
-            ParseSensorData();
-            SendCommand();
-        } else {
+            if (!IsAckMsgReceived()) {
+                SendInit();
+            } else {
+                ParseSensorData();
+                SendCommand();
+            }
+        }
+        else
+        {
             std::this_thread::yield();
         }
     }

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -161,6 +161,8 @@ bool Robot::IsReady()
 
 void Robot::WaitUntilReady()
 {
+    joints->SetZeroCommands();
+
     std::chrono::time_point<std::chrono::system_clock> last = std::chrono::system_clock::now();
     while (!IsReady() && !HasError())
     {


### PR DESCRIPTION
This makes the `Robot::WaitUntilReady()` closer to the way the `example.cpp` also works. There, the `SendInit()` is called in a loop until it gets acknowledged and then the main part of the program starts.