### PR TITLE
JointModules: Use Encoder A/B for error message

### DIFF
--- a/src/joint_modules.cpp
+++ b/src/joint_modules.cpp
@@ -396,7 +396,7 @@ bool JointModules::HasError()
                 switch (robot_if_->motor_drivers[i].error_code)
                 {
                     case UD_SENSOR_STATUS_ERROR_ENCODER1:
-                        msg_out_ << "Encoder1 error";
+                        msg_out_ << "Encoder A error";
                         break;
                     case UD_SENSOR_STATUS_ERROR_SPI_RECV_TIMEOUT:
                         msg_out_ << "SPI Receiver timeout";
@@ -411,7 +411,7 @@ bool JointModules::HasError()
                         msg_out_ << "Position rollover occured";
                         break;
                     case UD_SENSOR_STATUS_ERROR_ENCODER2:
-                        msg_out_ << "Encoder2 error";
+                        msg_out_ << "Encoder B error";
                         break;
                     default:
                         msg_out_ << "Other error (" << robot_if_->motor_drivers[i].error_code << ")";


### PR DESCRIPTION
Change the error message from "Encoder 1"/"Encoder 2" to "Encoder A" and "Encoder B". With the "1" I was never sure if we are counting from zero or not. In addition, we use the notion of channel A and B for the labeling of the micro drivers. So I think this is overall more consistent.