### PR TITLE
add missing include for std::shared_ptr

### DIFF
--- a/include/odri_control_interface/imu.hpp
+++ b/include/odri_control_interface/imu.hpp
@@ -14,6 +14,7 @@
 #include <math.h>
 #include <unistd.h>
 #include <stdexcept>
+#include <memory>
 
 #include "master_board_sdk/defines.h"
 #include "master_board_sdk/master_board_interface.h"

--- a/include/odri_control_interface/joint_modules.hpp
+++ b/include/odri_control_interface/joint_modules.hpp
@@ -14,6 +14,7 @@
 #include <unistd.h>
 #include <iostream>
 #include <vector>
+#include <memory>
 
 #include "master_board_sdk/defines.h"
 #include "master_board_sdk/master_board_interface.h"


### PR DESCRIPTION

## Description

Building on Arch with GCC 11.2.0 resulted in a couple of :
```cpp
In file included from odri_control_interface/src/joint_modules.cpp:12:
odri_control_interface/include/odri_control_interface/joint_modules.hpp:31:10: error: 'shared_ptr' in namespace 'std' does not name a template type
   31 |     std::shared_ptr<MasterBoardInterface> robot_if_;
      |          ^~~~~~~~~~
odri_control_interface/include/odri_control_interface/joint_modules.hpp:22:1: note: 'std::shared_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
   21 | #include <odri_control_interface/common.hpp>
  +++ |+#include <memory>
   22 |
```

## How I Tested

Compiled successfully

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
