### PR TITLE
Fix minor build error and update cmake submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,10 +53,8 @@ add_project_dependency(master_board_sdk REQUIRED)
 
 # Set component to fetch from boost Get the python interface for the bindings
 if(BUILD_PYTHON_INTERFACE)
-  findpython(REQUIRED)
-  search_for_boost_python(REQUIRED)
-  add_project_dependency(eigenpy 2.5.0 REQUIRED PKG_CONFIG_REQUIRES
-                         "eigenpy >= 2.5.0")
+  add_project_dependency(eigenpy 2.7.10 REQUIRED PKG_CONFIG_REQUIRES
+                         "eigenpy >= 2.7.10")
 endif(BUILD_PYTHON_INTERFACE)
 
 # ----------------------------------------------------
@@ -67,7 +65,7 @@ endif(BUILD_PYTHON_INTERFACE)
 set(ODRI_CONTROL_INTERFACE_SRC src/joint_modules.cpp src/imu.cpp src/robot.cpp
                                src/calibration.cpp src/utils.cpp)
 add_library(${PROJECT_NAME} SHARED ${ODRI_CONTROL_INTERFACE_SRC})
-target_link_libraries(${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} yaml-cpp)
 target_link_libraries(${PROJECT_NAME} master_board_sdk::master_board_sdk)
 target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
 target_include_directories(


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
I updated the cmake submodule and did a minor changes in the CMakelist so that the package compiles properly.

(Because I **had** these errors when following the build steps : 
```
CMake Error at CMakeLists.txt:92 (add_library):
  Target "odri_control_interface_pywrap" links to target "Python3::NumPy" but
  the target was not found.  Perhaps a find_package() call is missing for an
  IMPORTED target, or an ALIAS target is missing?
```
```
/home/.../devel/workspace/src/odri_control_interface/src/utils.cpp:12:10: fatal error: yaml-cpp/yaml.h: No such file or directory
   12 | #include <yaml-cpp/yaml.h>
      |          ^~~~~~~~~~~~~~~~~
```
)


## How I Tested
It compiled on my Ubuntu 20.04 afterwards.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
