### PR TITLE
UD_SENSOR_STATUS_CRC_ERROR not yet available in master-board

### DIFF
--- a/src/joint_modules.cpp
+++ b/src/joint_modules.cpp
@@ -428,9 +428,11 @@ bool JointModules::HasError()
                     case UD_SENSOR_STATUS_ERROR_ENCODER2:
                         msg_out_ << "Encoder B error";
                         break;
+                    /*
                     case UD_SENSOR_STATUS_CRC_ERROR:
                         msg_out_ << "CRC error in SPI transaction";
                         break;
+                    */
                     default:
                         msg_out_ << "Other error (" << robot_if_->motor_drivers[i].error_code << ")";
                         break;


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

I was too fast in merging #18, `UD_SENSOR_STATUS_CRC_ERROR` is not defined yet.


## How I Tested

Compiling

## I fulfilled the following requirements

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
