### PR TITLE
joint_modules: make destructor virtual for virtual class

### DIFF
--- a/include/odri_control_interface/joint_modules.hpp
+++ b/include/odri_control_interface/joint_modules.hpp
@@ -74,6 +74,7 @@ public:
                  ConstRefVectorXd upper_joint_limits,
                  double max_joint_velocities,
                  double safety_damping);
+    virtual ~JointModules();
 
     void Enable();
 

--- a/src/joint_modules.cpp
+++ b/src/joint_modules.cpp
@@ -92,6 +92,8 @@ JointModules::JointModules(
     SetMaximumCurrents(max_currents);
 }
 
+JointModules::~JointModules() {}
+
 const VectorXd& JointModules::GetGearRatios()
 {
     return gear_ratios_;


### PR DESCRIPTION
## Description

This PR fixes a compiler warning about the `JointModules` class having a virtual member function but a non-virtual destructor

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
