### PR TITLE
Scalars or lists for motor constants, gear ratios and max currents

### DIFF
--- a/include/odri_control_interface/joint_modules.hpp
+++ b/include/odri_control_interface/joint_modules.hpp
@@ -66,9 +66,9 @@ protected:
 public:
     JointModules(const std::shared_ptr<MasterBoardInterface>& robot_if,
                  ConstRefVectorXi motor_numbers,
-                 double motor_constants,
-                 double gear_ratios,
-                 double max_currents,
+                 ConstRefVectorXd motor_constants,
+                 ConstRefVectorXd gear_ratios,
+                 ConstRefVectorXd max_currents,
                  ConstRefVectorXb reverse_polarities,
                  ConstRefVectorXd lower_joint_limits,
                  ConstRefVectorXd upper_joint_limits,
@@ -85,7 +85,7 @@ public:
     void SetDesiredVelocities(ConstRefVectorXd desired_velocities);
     void SetPositionGains(ConstRefVectorXd desired_gains);
     void SetVelocityGains(ConstRefVectorXd desired_gains);
-    void SetMaximumCurrents(double max_currents);
+    void SetMaximumCurrents(ConstRefVectorXd max_currents);
 
     /**
      * @brief Disables the position and velocity gains by setting them to zero.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -108,18 +108,99 @@ std::shared_ptr<JointModules> JointModulesFromYaml(
         upper_joint_limits_vec(i) = upper_joint_limits[i].as<double>();
     }
 
+    // "motor_constants" can be either a scalar (same value for all motors) or a list
     assert_yaml_parsing(joint_modules_yaml, "joint_modules", "motor_constants");
+    const YAML::Node& motor_constants = joint_modules_yaml["motor_constants"];
+    VectorXd motor_constants_vec;
+    motor_constants_vec.resize(n);
+    switch (motor_constants.Type()) {
+        case YAML::NodeType::Scalar:
+            for (std::size_t i = 0; i < n; i++)
+            {
+                motor_constants_vec(i) = motor_constants.as<double>();
+            }
+            break;
+        case YAML::NodeType::Sequence:
+            if (motor_constants.size() != n)
+            {
+                throw std::runtime_error(
+                    "Motor constants list has different size than motor numbers.");
+            }
+            for (std::size_t i = 0; i < n; i++)
+            {
+                motor_constants_vec(i) = motor_constants[i].as<double>();
+            }
+            break;
+        default:
+            throw std::runtime_error(
+                "Motor constants should be either a scalar or a list.");
+        }
+
+    // "gear_ratios" can be either a scalar (same value for all motors) or a list
     assert_yaml_parsing(joint_modules_yaml, "joint_modules", "gear_ratios");
+    const YAML::Node& gear_ratios = joint_modules_yaml["gear_ratios"];
+    VectorXd gear_ratios_vec;
+    gear_ratios_vec.resize(n);
+    switch (gear_ratios.Type()) {
+        case YAML::NodeType::Scalar:
+            for (std::size_t i = 0; i < n; i++)
+            {
+                gear_ratios_vec(i) = gear_ratios.as<double>();
+            }
+            break;
+        case YAML::NodeType::Sequence:
+            if (gear_ratios.size() != n)
+            {
+                throw std::runtime_error(
+                    "Gear ratio list has different size than motor numbers.");
+            }
+            for (std::size_t i = 0; i < n; i++)
+            {
+                gear_ratios_vec(i) = gear_ratios[i].as<double>();
+            }
+            break;
+        default:
+            throw std::runtime_error(
+                "Gear ratio should be either a scalar or a list.");
+        }
+
+    // "max_currents" can be either a scalar (same value for all motors) or a list
     assert_yaml_parsing(joint_modules_yaml, "joint_modules", "max_currents");
+    const YAML::Node& max_currents = joint_modules_yaml["max_currents"];
+    VectorXd max_currents_vec;
+    max_currents_vec.resize(n);
+    switch (max_currents.Type()) {
+        case YAML::NodeType::Scalar:
+            for (std::size_t i = 0; i < n; i++)
+            {
+                max_currents_vec(i) = max_currents.as<double>();
+            }
+            break;
+        case YAML::NodeType::Sequence:
+            if (max_currents.size() != n)
+            {
+                throw std::runtime_error(
+                    "Max currents list has different size than motor numbers.");
+            }
+            for (std::size_t i = 0; i < n; i++)
+            {
+                max_currents_vec(i) = max_currents[i].as<double>();
+            }
+            break;
+        default:
+            throw std::runtime_error(
+                "Max currents should be either a scalar or a list.");
+        }
+
     assert_yaml_parsing(
         joint_modules_yaml, "joint_modules", "max_joint_velocities");
     assert_yaml_parsing(joint_modules_yaml, "joint_modules", "safety_damping");
     return std::make_shared<JointModules>(
         robot_if,
         motor_numbers_vec,
-        joint_modules_yaml["motor_constants"].as<double>(),
-        joint_modules_yaml["gear_ratios"].as<double>(),
-        joint_modules_yaml["max_currents"].as<double>(),
+        motor_constants_vec,
+        gear_ratios_vec,
+        max_currents_vec,
         rev_polarities_vec,
         lower_joint_limits_vec,
         upper_joint_limits_vec,

--- a/srcpy/bindings.cpp
+++ b/srcpy/bindings.cpp
@@ -46,9 +46,9 @@ std::shared_ptr<JointCalibrator> joint_calibrator_constructor(
 std::shared_ptr<JointModules> joint_modules_constructor(
     const std::shared_ptr<MasterBoardInterface>& robot_if,
     ConstRefVectorXl motor_numbers,
-    double motor_constants,
-    double gear_ratios,
-    double max_currents,
+    ConstRefVectorXd motor_constants,
+    ConstRefVectorXd gear_ratios,
+    ConstRefVectorXd max_currents,
     ConstRefVectorXb reverse_polarities,
     ConstRefVectorXd lower_joint_limits,
     ConstRefVectorXd upper_joint_limits,


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

Right now, motor constants, gear ratios and max currents are scalars in the yaml configuration file for ODRI control interface. For instance, for Solo-12 it could be:
```
        motor_constants: 0.025
        gear_ratios: 9.
        max_currents: 8.
```
Internally, these quantities are already handled as vectors, the scalar value simply fills the whole vector.

With this PR, the motor constants, gear ratios and max currents can be specified per motor, which makes possible the use of robots with more complex designs, like having a different gear ratio for the knee joints compared the HAA and HFE.

You could have for instance:
```
        motor_constants: 0.025
        gear_ratios: [9., 9., 12., 9., 9., 12., 9., 9., 12., 9., 9., 12.]
        max_currents: [8., 8., 10., 8., 8., 10., 8., 8., 10., 8., 8., 10.]
```

The detection of the data type is automatic, so the behavior remains the same for people that do not use this new feature.

## How I Tested

[//]: # "Explain how you tested your changes"

I compiled the code and launched it several times on our Solo-12 with debug outputs in the code to check that the data in the configuration file was properly detected and loaded.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).

For the `.clang-format` file, I am not sure which one is used for the style of this repository. I tried to keep the same style than the existing code.