### PR TITLE
release: Update package.xml version to 1.0.1

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
 <package format="2">
 
     <name>odri_control_interface</name>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <description>
 	Common interface for controlling robots build with the odri master board.


### PR DESCRIPTION
## Description

This PR proposes to make a release of odri_control_interface. As so far the version was set to  `1.0.0`, I propose to switch to `1.0.1` 

## How I Tested

## I fulfilled the following requirements

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings). But this repository does not have clang-format etc...
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it). 
They are no tests, so I just did the compilation. But the good news is that it is working on Noble/Jazzy (with ros-jazzy-eigenpy), there is only a small warning on the cmake version. 
